### PR TITLE
Cleanup and linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+lint:
+	pip install flake8
+	flake8 .

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,13 @@ from setuptools import setup
 from pytest_circleci import __version__
 from pytest_circleci import plugin
 
+
 setup(
     name="pytest-circleci",
     version=__version__,
     description="py.test plugin for CircleCI",
-    long_description=textwrap.dedent(plugin.pytest_collection_modifyitems.__doc__),
+    long_description=textwrap.dedent(
+        plugin.pytest_collection_modifyitems.__doc__),
     author="Michael Twomey",
     author_email="mick@twomeylee.name",
     url="https://github.com/micktwomey/pytest-circleci",


### PR DESCRIPTION
This adjusts the code to be pep8 compliant.

Specifically:
- Break up single line multi-import
- Ensure lines are < 80 characters
- Add `make lint` command to install and run flake8
