### PR TITLE
Python 3 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	pip install tox
+	tox

--- a/pytest_circleci/plugin.py
+++ b/pytest_circleci/plugin.py
@@ -36,7 +36,8 @@ def pytest_collection_modifyitems(session, config, items):
     circle_node_total, circle_node_index = read_circleci_env_variables()
     deselected = []
     for index, item in enumerate(list(items)):
-        item_hash = int(hashlib.sha1(':'.join(map(str, item.location))).hexdigest(), 16)
+        item_location = ':'.join(map(str, item.location)).encode()
+        item_hash = int(hashlib.sha1(item_location).hexdigest(), 16)
         if (item_hash % circle_node_total) != circle_node_index:
             deselected.append(item)
             items.remove(item)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,45 @@
+import mock
+
+from pytest_circleci.plugin import pytest_collection_modifyitems
+
+
+class Item:
+    location = 'location'
+
+
+@mock.patch('pytest_circleci.plugin.hashlib')
+@mock.patch('pytest_circleci.plugin.read_circleci_env_variables')
+def test_first_container(read_circleci_env_variables_mock, hashlib):
+    item1 = Item()
+    item2 = Item()
+    item3 = Item()
+    item4 = Item()
+    items = [item1, item2, item3, item4]
+    sha1 = mock.sentinel
+    sha1.hexdigest = mock.Mock(side_effect=['1', '2', '3', '4'])
+    hashlib.sha1 = mock.Mock(return_value=sha1)
+    config = mock.Mock()
+    read_circleci_env_variables_mock.return_value = (2, 0)
+
+    pytest_collection_modifyitems('session', config, items)
+
+    config.hook.pytest_deselected.assert_called_with(items=[item1, item3])
+
+
+@mock.patch('pytest_circleci.plugin.hashlib')
+@mock.patch('pytest_circleci.plugin.read_circleci_env_variables')
+def test_second_container(read_circleci_env_variables_mock, hashlib):
+    item1 = Item()
+    item2 = Item()
+    item3 = Item()
+    item4 = Item()
+    items = [item1, item2, item3, item4]
+    sha1 = mock.sentinel
+    sha1.hexdigest = mock.Mock(side_effect=['1', '2', '3', '4'])
+    hashlib.sha1 = mock.Mock(return_value=sha1)
+    config = mock.Mock()
+    read_circleci_env_variables_mock.return_value = (2, 1)
+
+    pytest_collection_modifyitems('session', config, items)
+
+    config.hook.pytest_deselected.assert_called_with(items=[item2, item4])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+deps = 
+    pytest
+    mock
+commands = py.test


### PR DESCRIPTION
Needed an `.encode()` modifier to get this working on py34.  I added a simple unit test just to show it not breaking on both versions of Python.
